### PR TITLE
refactor: migrate to SecretsManager pattern

### DIFF
--- a/decart/decart_lucy_video_edit.py
+++ b/decart/decart_lucy_video_edit.py
@@ -11,7 +11,6 @@ from griptape.artifacts import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
 
@@ -213,7 +212,7 @@ class DecartLucyVideoEdit(DataNode):
         return output_video 
         
     def _validate_api_key(self) -> str:
-        api_key = self.get_config_value(service=self.SERVICE_NAME, value=self.API_KEY_ENV_VAR)
+        api_key = GriptapeNodes.SecretsManager().get_secret(self.API_KEY_ENV_VAR)
         if not api_key:
             msg = f"{self.name} is missing {self.API_KEY_ENV_VAR}. Ensure it's set in the environment/config."
             raise ValueError(msg)

--- a/decart/griptape_nodes_library.json
+++ b/decart/griptape_nodes_library.json
@@ -3,11 +3,13 @@
   "library_schema_version": "0.1.0",
   "settings": [
     {
-        "description": "Environment variables for Decart API access",
-        "category": "nodes.Decart",
-        "contents": {
-            "DECART_API_KEY": "$DECART_API_KEY"
-        }
+      "description": "API keys required by nodes in this library",
+      "category": "app_events.on_app_initialization_complete",
+      "contents": {
+        "secrets_to_register": [
+          "DECART_API_KEY"
+        ]
+      }
     }
   ],
   "metadata": {


### PR DESCRIPTION
- Updated decart_lucy_video_edit.py to use GriptapeNodes.SecretsManager().get_secret()
- Replaced get_config_value(service=SERVICE_NAME, value=API_KEY_ENV_VAR) pattern
- Updated griptape_nodes_library.json to use secrets_to_register array
- Changed category to app_events.on_app_initialization_complete
- Removed unused Options import
- Maintains backwards compatibility with same error messages