### PR TITLE
feat: replace bespoke loading logic with File class

### DIFF
--- a/decart/decart_lucy_dev_i2v.py
+++ b/decart/decart_lucy_dev_i2v.py
@@ -8,6 +8,7 @@ from io import BytesIO
 import requests
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact, VideoUrlArtifact
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -124,9 +125,7 @@ class DecartLucyDevI2V(DataNode):
                     
             elif value.startswith(("http://", "https://")):
                 # Handle URL in dictionary
-                response = requests.get(value)
-                response.raise_for_status()
-                image_bytes = response.content
+                image_bytes = File(value).read_bytes()
                 
                 # Extract filename from URL
                 url_path = value.split('/')[-1]

--- a/decart/decart_lucy_dev_v2v.py
+++ b/decart/decart_lucy_dev_v2v.py
@@ -10,6 +10,7 @@ import requests
 from griptape.artifacts import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 
@@ -121,9 +122,7 @@ class DecartLucyDevV2V(DataNode):
                     
             elif value.startswith(("http://", "https://")):
                 # Handle URL in dictionary
-                response = requests.get(value)
-                response.raise_for_status()
-                video_bytes = response.content
+                video_bytes = File(value).read_bytes()
                 
                 # Extract filename from URL
                 url_path = value.split('/')[-1]

--- a/decart/decart_lucy_pro_i2i.py
+++ b/decart/decart_lucy_pro_i2i.py
@@ -8,6 +8,7 @@ from io import BytesIO
 import requests
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -134,9 +135,7 @@ class DecartLucyProI2I(DataNode):
                     
             elif value.startswith(("http://", "https://")):
                 # Handle URL in dictionary
-                response = requests.get(value)
-                response.raise_for_status()
-                image_bytes = response.content
+                image_bytes = File(value).read_bytes()
                 
                 # Extract filename from URL
                 url_path = value.split('/')[-1]

--- a/decart/decart_lucy_pro_i2v.py
+++ b/decart/decart_lucy_pro_i2v.py
@@ -8,6 +8,7 @@ from io import BytesIO
 import requests
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact, VideoUrlArtifact
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -123,9 +124,7 @@ class DecartLucyProI2V(DataNode):
                     
             elif value.startswith(("http://", "https://")):
                 # Handle URL in dictionary
-                response = requests.get(value)
-                response.raise_for_status()
-                image_bytes = response.content
+                image_bytes = File(value).read_bytes()
                 
                 # Extract filename from URL
                 url_path = value.split('/')[-1]

--- a/decart/decart_lucy_video_edit.py
+++ b/decart/decart_lucy_video_edit.py
@@ -8,6 +8,7 @@ from io import BytesIO
 import requests
 
 from griptape.artifacts import VideoUrlArtifact
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -100,9 +101,7 @@ class DecartLucyVideoEdit(DataNode):
                     
             elif value.startswith(("http://", "https://")):
                 # Handle URL in dictionary
-                response = requests.get(value)
-                response.raise_for_status()
-                video_bytes = response.content
+                video_bytes = File(value).read_bytes()
                 
                 # Extract filename from URL
                 url_path = value.split('/')[-1]

--- a/decart/griptape_nodes_library.json
+++ b/decart/griptape_nodes_library.json
@@ -107,5 +107,6 @@
         "display_name": "Decart Lucy Pro I2I"
       }
     }
-  ]
+  ],
+  "engine_version": "0.75.0"
 }


### PR DESCRIPTION
## Summary
- Replace `requests.get` URL download calls with `File(url).read_bytes()` in image/video conversion methods
- Bump `engine_version` to `0.75.0`
- API POST calls (job submission) are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)