### PR TITLE
feat: migrate save_static_file to ProjectFileParameter

### DIFF
--- a/decart/decart_lucy_dev_i2v.py
+++ b/decart/decart_lucy_dev_i2v.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 import base64
 import logging
-import uuid
 from io import BytesIO
 
 import requests
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact, VideoUrlArtifact
-from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +90,8 @@ class DecartLucyDevI2V(DataNode):
                 ui_options={"display_name": "Output Video"}
             )
         )
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="decart_video.mp4")
+        self._output_file.add_parameter()
 
     def validate_node(self) -> list[Exception] | None:
         return None
@@ -173,15 +174,12 @@ class DecartLucyDevI2V(DataNode):
         """
         if not response_content:
             raise ValueError("Empty response content - no video data received")
-        
-        # Generate a unique filename for the output video
-        filename = f"decart_i2v_output_{uuid.uuid4()}.mp4"
-        
-        # Save the video bytes to the static file server
-        url = GriptapeNodes.StaticFilesManager().save_static_file(response_content, filename, ExistingFilePolicy.CREATE_NEW)
-        
+
+        # Save the video bytes to the project file
+        saved = self._output_file.build_file().write_bytes(response_content)
+
         # Create and return VideoUrlArtifact with the URL
-        return VideoUrlArtifact(url)
+        return VideoUrlArtifact(saved.location)
 
     def process(self) -> AsyncResult[None]:
         yield lambda: self._process()

--- a/decart/decart_lucy_dev_v2v.py
+++ b/decart/decart_lucy_dev_v2v.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import logging
-import uuid
 from io import BytesIO
 
 import requests
@@ -10,9 +9,9 @@ import requests
 from griptape.artifacts import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +87,8 @@ class DecartLucyDevV2V(DataNode):
                 ui_options={"display_name": "Output Video"}
             )
         )
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="decart_video.mp4")
+        self._output_file.add_parameter()
 
     def validate_node(self) -> list[Exception] | None:
         return None
@@ -170,15 +171,12 @@ class DecartLucyDevV2V(DataNode):
         """
         if not response_content:
             raise ValueError("Empty response content - no video data received")
-        
-        # Generate a unique filename for the output video
-        filename = f"decart_v2v_output_{uuid.uuid4()}.mp4"
-        
-        # Save the video bytes to the static file server
-        url = GriptapeNodes.StaticFilesManager().save_static_file(response_content, filename, ExistingFilePolicy.CREATE_NEW)
-        
+
+        # Save the video bytes to the project file
+        saved = self._output_file.build_file().write_bytes(response_content)
+
         # Create and return VideoUrlArtifact with the URL
-        return VideoUrlArtifact(url)
+        return VideoUrlArtifact(saved.location)
 
     def process(self) -> AsyncResult[None]:
         yield lambda: self._process()

--- a/decart/decart_lucy_pro_i2i.py
+++ b/decart/decart_lucy_pro_i2i.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 import base64
 import logging
-import uuid
 from io import BytesIO
 
 import requests
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
-from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
@@ -101,6 +100,8 @@ class DecartLucyProI2I(DataNode):
                 ui_options={"display_name": "Output Image"}
             )
         )
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="decart_image.png")
+        self._output_file.add_parameter()
 
     def validate_node(self) -> list[Exception] | None:
         return None
@@ -183,15 +184,12 @@ class DecartLucyProI2I(DataNode):
         """
         if not response_content:
             raise ValueError("Empty response content - no image data received")
-        
-        # Generate a unique filename for the output image
-        filename = f"decart_pro_i2i_output_{uuid.uuid4()}.png"
-        
-        # Save the image bytes to the static file server
-        url = GriptapeNodes.StaticFilesManager().save_static_file(response_content, filename, ExistingFilePolicy.CREATE_NEW)
-        
+
+        # Save the image bytes to the project file
+        saved = self._output_file.build_file().write_bytes(response_content)
+
         # Create and return ImageUrlArtifact with the URL
-        return ImageUrlArtifact(url)
+        return ImageUrlArtifact(saved.location)
 
     def process(self) -> AsyncResult[None]:
         yield lambda: self._process()

--- a/decart/decart_lucy_pro_i2v.py
+++ b/decart/decart_lucy_pro_i2v.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 import base64
 import logging
-import uuid
 from io import BytesIO
 
 import requests
 
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact, VideoUrlArtifact
-from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
@@ -90,6 +89,8 @@ class DecartLucyProI2V(DataNode):
                 ui_options={"display_name": "Output Video"}
             )
         )
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="decart_video.mp4")
+        self._output_file.add_parameter()
 
     def validate_node(self) -> list[Exception] | None:
         return None
@@ -172,15 +173,12 @@ class DecartLucyProI2V(DataNode):
         """
         if not response_content:
             raise ValueError("Empty response content - no video data received")
-        
-        # Generate a unique filename for the output video
-        filename = f"decart_pro_i2v_output_{uuid.uuid4()}.mp4"
-        
-        # Save the video bytes to the static file server
-        url = GriptapeNodes.StaticFilesManager().save_static_file(response_content, filename, ExistingFilePolicy.CREATE_NEW)
-        
+
+        # Save the video bytes to the project file
+        saved = self._output_file.build_file().write_bytes(response_content)
+
         # Create and return VideoUrlArtifact with the URL
-        return VideoUrlArtifact(url)
+        return VideoUrlArtifact(saved.location)
 
     def process(self) -> AsyncResult[None]:
         yield lambda: self._process()

--- a/decart/decart_lucy_pro_t2i.py
+++ b/decart/decart_lucy_pro_t2i.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import logging
-import uuid
 
 import requests
 
 from griptape.artifacts import ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
@@ -87,6 +86,8 @@ class DecartLucyProT2I(DataNode):
                 ui_options={"display_name": "Output Image"}
             )
         )
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="decart_image.png")
+        self._output_file.add_parameter()
 
     def validate_node(self) -> list[Exception] | None:
         return None
@@ -105,15 +106,12 @@ class DecartLucyProT2I(DataNode):
         """
         if not response_content:
             raise ValueError("Empty response content - no image data received")
-        
-        # Generate a unique filename for the output image
-        filename = f"decart_t2i_output_{uuid.uuid4()}.png"
-        
-        # Save the image bytes to the static file server
-        url = GriptapeNodes.StaticFilesManager().save_static_file(response_content, filename, ExistingFilePolicy.CREATE_NEW)
-        
+
+        # Save the image bytes to the project file
+        saved = self._output_file.build_file().write_bytes(response_content)
+
         # Create and return ImageUrlArtifact with the URL
-        return ImageUrlArtifact(url)
+        return ImageUrlArtifact(saved.location)
 
     def process(self) -> AsyncResult[None]:
         yield lambda: self._process()

--- a/decart/decart_lucy_pro_t2v.py
+++ b/decart/decart_lucy_pro_t2v.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import logging
-import uuid
 
 import requests
 
 from griptape.artifacts import VideoUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 from griptape_nodes.traits.options import Options
 
 logger = logging.getLogger(__name__)
@@ -88,6 +87,8 @@ class DecartLucyProT2V(DataNode):
                 ui_options={"display_name": "Output Video"}
             )
         )
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="decart_video.mp4")
+        self._output_file.add_parameter()
 
     def validate_node(self) -> list[Exception] | None:
         return None
@@ -106,15 +107,12 @@ class DecartLucyProT2V(DataNode):
         """
         if not response_content:
             raise ValueError("Empty response content - no video data received")
-        
-        # Generate a unique filename for the output video
-        filename = f"decart_t2v_output_{uuid.uuid4()}.mp4"
-        
-        # Save the video bytes to the static file server
-        url = GriptapeNodes.StaticFilesManager().save_static_file(response_content, filename, ExistingFilePolicy.CREATE_NEW)
-        
+
+        # Save the video bytes to the project file
+        saved = self._output_file.build_file().write_bytes(response_content)
+
         # Create and return VideoUrlArtifact with the URL
-        return VideoUrlArtifact(url)
+        return VideoUrlArtifact(saved.location)
 
     def process(self) -> AsyncResult[None]:
         yield lambda: self._process()

--- a/decart/decart_lucy_video_edit.py
+++ b/decart/decart_lucy_video_edit.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 import base64
 import logging
-import uuid
 from io import BytesIO
 
 import requests
 
 from griptape.artifacts import VideoUrlArtifact
-from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.files.file import File, FileLoadError
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +66,8 @@ class DecartLucyVideoEdit(DataNode):
                 ui_options={"display_name": "Output Video"}
             )
         )
+        self._output_file = ProjectFileParameter(node=self, name="output_file", default_filename="decart_video.mp4")
+        self._output_file.add_parameter()
 
     def validate_node(self) -> list[Exception] | None:
         return None
@@ -149,15 +150,12 @@ class DecartLucyVideoEdit(DataNode):
         """
         if not response_content:
             raise ValueError("Empty response content - no video data received")
-        
-        # Generate a unique filename for the output video
-        filename = f"decart_output_{uuid.uuid4()}.mp4"
-        
-        # Save the video bytes to the static file server
-        url = GriptapeNodes.StaticFilesManager().save_static_file(response_content, filename, ExistingFilePolicy.CREATE_NEW)
-        
+
+        # Save the video bytes to the project file
+        saved = self._output_file.build_file().write_bytes(response_content)
+
         # Create and return VideoUrlArtifact with the URL
-        return VideoUrlArtifact(url)
+        return VideoUrlArtifact(saved.location)
 
     def process(self) -> AsyncResult[None]:
         yield lambda: self._process()


### PR DESCRIPTION
Closes #7

Replace `StaticFilesManager.save_static_file()` with `ProjectFileParameter` for project-aware file saving.